### PR TITLE
Task-9 - Add parameters to the query

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,10 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+export const config = {
+  nasaApiKey: process.env.NASA_API_KEY,
+  nasaApiUrl: process.env.NASA_API_URL,
+  monday: "2024-10-07",
+  friday: "2024-10-11",
+};

--- a/config.js
+++ b/config.js
@@ -5,6 +5,4 @@ dotenv.config();
 export const config = {
   nasaApiKey: process.env.NASA_API_KEY,
   nasaApiUrl: process.env.NASA_API_URL,
-  monday: "2024-10-07",
-  friday: "2024-10-11",
 };

--- a/delivery/meteorsRouter.js
+++ b/delivery/meteorsRouter.js
@@ -5,7 +5,12 @@ const meteorRouter = express.Router();
 
 meteorRouter.get("/meteors", async (request, response) => {
   try {
-    const meteors = await fetchMeteors();
+    const { date, count, wereDangerousMeteors } = request.query;
+    if (date === undefined || date === null) {
+      return response.status(400).json({ error: "Missing date parameter" });
+    }
+
+    const meteors = await fetchMeteors(date, count, wereDangerousMeteors);
     return response.json(meteors);
   } catch (error) {
     return response.status(500).json({ error: "Faild to fetch data." });

--- a/delivery/meteorsRouter.js
+++ b/delivery/meteorsRouter.js
@@ -1,0 +1,15 @@
+import express from "express";
+import fetchMeteors from "../useCases/fetchMeteors.js";
+
+const meteorRouter = express.Router();
+
+meteorRouter.get("/meteors", async (request, response) => {
+  try {
+    const meteors = await fetchMeteors();
+    return response.json(meteors);
+  } catch (error) {
+    return response.status(500).json({ error: "Faild to fetch data." });
+  }
+});
+
+export default meteorRouter;

--- a/delivery/meteorsRouter.js
+++ b/delivery/meteorsRouter.js
@@ -6,7 +6,7 @@ const meteorRouter = express.Router();
 meteorRouter.get("/meteors", async (request, response) => {
   try {
     const { date, count, wereDangerousMeteors } = request.query;
-    if (date === undefined || date === null) {
+    if (!date) {
       return response.status(400).json({ error: "Missing date parameter" });
     }
 

--- a/index.js
+++ b/index.js
@@ -1,45 +1,14 @@
 import dotenv from "dotenv";
-import axios from "axios";
 import express from "express";
+import meteorRouter from "./delivery/meteorsRouter.js";
 
 dotenv.config();
-const { NASA_API_KEY, PORT, NASA_API_URL } = process.env;
+const { PORT } = process.env;
 
 const app = express();
 
+app.use(meteorRouter);
+
 app.listen(PORT, () => {
   console.log(`Server is running on port: ${PORT}`);
-});
-
-const monday = "2024-10-07";
-const friday = "2024-10-11";
-
-const url = `${NASA_API_URL}?start_date=${monday}&end_date=${friday}&api_key=${NASA_API_KEY}`;
-
-app.get("/meteors", async (request, response) => {
-  try {
-    const result = await axios.get(url);
-
-    const data = Object.values(result.data.near_earth_objects).flatMap(
-      (meteors) =>
-        meteors.map((item) => ({
-          id: item.id,
-          name: item.name,
-          diameter:
-            (item.estimated_diameter.meters.estimated_diameter_min +
-              item.estimated_diameter.meters.estimated_diameter_max) /
-            2,
-          is_potentially_hazardous_asteroid:
-            item.is_potentially_hazardous_asteroid,
-          close_approach_date_full:
-            item.close_approach_data[0].close_approach_date_full,
-          relative_velocity:
-            item.close_approach_data[0].relative_velocity.kilometers_per_second,
-        }))
-    );
-
-    response.json(data);
-  } catch (error) {
-    response.status(500).json({ error: "Faild to fetch data." });
-  }
 });

--- a/index.js
+++ b/index.js
@@ -20,7 +20,25 @@ app.get("/meteors", async (request, response) => {
   try {
     const result = await axios.get(url);
 
-    response.json(result.data);
+    const data = Object.values(result.data.near_earth_objects).flatMap(
+      (meteors) =>
+        meteors.map((item) => ({
+          id: item.id,
+          name: item.name,
+          diameter:
+            (item.estimated_diameter.meters.estimated_diameter_min +
+              item.estimated_diameter.meters.estimated_diameter_max) /
+            2,
+          is_potentially_hazardous_asteroid:
+            item.is_potentially_hazardous_asteroid,
+          close_approach_date_full:
+            item.close_approach_data[0].close_approach_date_full,
+          relative_velocity:
+            item.close_approach_data[0].relative_velocity.kilometers_per_second,
+        }))
+    );
+
+    response.json(data);
   } catch (error) {
     response.status(500).json({ error: "Faild to fetch data." });
   }

--- a/repository/meteorRepository.js
+++ b/repository/meteorRepository.js
@@ -14,7 +14,7 @@ const getMondayAndFridayOfWeek = async (date) => {
   const givenDate = new Date(date);
   const dayOfWeek = givenDate.getDay();
 
-  const distanceToMonday = (dayOfWeek + 6) % 7;
+  const distanceToMonday = dayOfWeek - 1;
   const monday = new Date(givenDate);
   monday.setDate(givenDate.getDate() - distanceToMonday);
 

--- a/repository/meteorRepository.js
+++ b/repository/meteorRepository.js
@@ -1,11 +1,35 @@
 import axios from "axios";
 import { config } from "../config.js";
 
-const url = `${config.nasaApiUrl}?start_date=${config.monday}&end_date=${config.friday}&api_key=${config.nasaApiKey}`;
+const getMeteors = async (date) => {
+  const { monday, friday } = await getMondayAndFridayOfWeek(date);
 
-const getMeteors = async () => {
+  const url = `${config.nasaApiUrl}?start_date=${monday}&end_date=${friday}&api_key=${config.nasaApiKey}`;
+
   const result = await axios.get(url);
   return result.data.near_earth_objects;
+};
+
+const getMondayAndFridayOfWeek = async (date) => {
+  const givenDate = new Date(date);
+  const dayOfWeek = givenDate.getDay();
+
+  const distanceToMonday = (dayOfWeek + 6) % 7;
+  const monday = new Date(givenDate);
+  monday.setDate(givenDate.getDate() - distanceToMonday);
+
+  const distanceToFriday = 5 - dayOfWeek;
+  const friday = new Date(givenDate);
+  friday.setDate(givenDate.getDate() + distanceToFriday);
+
+  return { monday: formatDate(monday), friday: formatDate(friday) };
+};
+
+const formatDate = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 };
 
 export default getMeteors;

--- a/repository/meteorRepository.js
+++ b/repository/meteorRepository.js
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { config } from "../config.js";
+
+const url = `${config.nasaApiUrl}?start_date=${config.monday}&end_date=${config.friday}&api_key=${config.nasaApiKey}`;
+
+const getMeteors = async () => {
+  const result = await axios.get(url);
+  return result.data.near_earth_objects;
+};
+
+export default getMeteors;

--- a/repository/meteorRepository.js
+++ b/repository/meteorRepository.js
@@ -14,7 +14,7 @@ const getMondayAndFridayOfWeek = async (date) => {
   const givenDate = new Date(date);
   const dayOfWeek = givenDate.getDay();
 
-  const distanceToMonday = (dayOfWeek + 6) % 7;
+  const distanceToMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
   const monday = new Date(givenDate);
   monday.setDate(givenDate.getDate() - distanceToMonday);
 

--- a/useCases/fetchMeteors.js
+++ b/useCases/fetchMeteors.js
@@ -1,9 +1,18 @@
 import getMeteors from "../repository/meteorRepository.js";
 
-const fetchMeteors = async () => {
-  let result = await getMeteors();
+const fetchMeteors = async (date, count, wereDangerousMeteors) => {
+  let meteors = await getMeteors(date);
+  let mappedMeteors = await mapMeteors(meteors);
+  let filteredMeteors = await filterMeteors(
+    mappedMeteors,
+    count,
+    wereDangerousMeteors
+  );
+  return filteredMeteors;
+};
 
-  return Object.values(result).flatMap((meteors) =>
+const mapMeteors = async (meteorsData) => {
+  return Object.values(meteorsData).flatMap((meteors) =>
     meteors.map((item) => ({
       id: item.id,
       name: item.name,
@@ -18,6 +27,21 @@ const fetchMeteors = async () => {
         item.close_approach_data[0].relative_velocity.kilometers_per_second,
     }))
   );
+};
+
+const filterMeteors = async (meteors, count, wereDangerousMeteors) => {
+  if (wereDangerousMeteors != null) {
+    const isWereDangerousMeteors = wereDangerousMeteors === "true";
+    meteors = meteors.filter(
+      (meteor) =>
+        meteor.is_potentially_hazardous_asteroid === isWereDangerousMeteors
+    );
+  }
+  if (count && !isNaN(count) && count > 0) {
+    meteors = meteors.slice(0, parseInt(count));
+  }
+
+  return meteors;
 };
 
 export default fetchMeteors;

--- a/useCases/fetchMeteors.js
+++ b/useCases/fetchMeteors.js
@@ -1,0 +1,23 @@
+import getMeteors from "../repository/meteorRepository.js";
+
+const fetchMeteors = async () => {
+  let result = await getMeteors();
+
+  return Object.values(result).flatMap((meteors) =>
+    meteors.map((item) => ({
+      id: item.id,
+      name: item.name,
+      diameter:
+        (item.estimated_diameter.meters.estimated_diameter_min +
+          item.estimated_diameter.meters.estimated_diameter_max) /
+        2,
+      is_potentially_hazardous_asteroid: item.is_potentially_hazardous_asteroid,
+      close_approach_date_full:
+        item.close_approach_data[0].close_approach_date_full,
+      relative_velocity:
+        item.close_approach_data[0].relative_velocity.kilometers_per_second,
+    }))
+  );
+};
+
+export default fetchMeteors;


### PR DESCRIPTION
https://github.com/LovchevaKate/NodeProxyServer/pull/6

Task-9: Add parameters to the query

In this task, we need to extend the capabilities of the existing endpoint /meteors.

We will pass query parameters in the query to control the logic on the server.
Query params:
-date helps to set the period during which we are interested in information on meteorites
-count returns only the number of meteorites that have been seen.
-were-dangerous-meteors returns true or false whether they have been seen among meteorites potentially dangerous to Earth.

P.S. consider the possibility of transferring several parameters at the same time

Acceptance criteria:

- Add date as a parameter to the query
- Add count as a parameter to the query
- Add were-dangerous-meteors as a parameter to the request
- Consider the possibility of passing several, all or none of the parameters